### PR TITLE
Fixed an issue where url parameters such as limit and offset were being ...

### DIFF
--- a/lib/http-helper.js
+++ b/lib/http-helper.js
@@ -216,8 +216,8 @@ module.exports = {
 
         var allParams;
 
-        allParams = _.merge(connection.urlParameters, 
-                            action.urlParameters || {}, 
+        allParams = _.merge(_.cloneDeep(connection.urlParameters),
+                            _.cloneDeep(action.urlParameters) || {}, 
                             urlParams || {});
 
         _.keys(allParams).forEach(function(key) {
@@ -231,7 +231,7 @@ module.exports = {
     constructHeaders: function(connection, action, context) {
         var self = this;
         //Merge all headers, action headers take precedence over adapter/connection headers
-        var headers = _.merge(connection.headers, action.headers);
+        var headers = _.merge(_.cloneDeep(connection.headers), _.cloneDeep(action.headers));
 
         _.keys(headers).forEach(function(key) {
             headers[key] = self.interpolate(headers[key], context);


### PR DESCRIPTION
...merged into the connection configuration and then used on all subsequent requests. Objects containing configuration and params are now cloned before being merged together.
