### PR TITLE
[#89236520] Scope query params are automatically appended to the outgoin...

### DIFF
--- a/lib/http-helper.js
+++ b/lib/http-helper.js
@@ -19,9 +19,29 @@ var maps = {
 };
 
 function HttpHelper(connection, model, action, urlParams, values, context) {
+    var queryParams = (function() {
+        if (context.query && context.query.query && context.query.scope) return context.query.query;
+        return {};
+    })();
+
+    function mapQueryParams() {
+        var q = {}, 
+            map = action.mapping.request,
+            keys = _.keys(queryParams);
+
+        if (keys.length === 0) return q;
+
+        keys.forEach(function(key) {
+            q[map[key] || key] = queryParams[key];
+        });
+
+        return q;
+    }
+
     return {
         interpolate: function(source) {
             if (!source) return '';
+            if (!_.isString(source)) source = source.toString();
             if (source.indexOf('{{') === -1) return source;
 
             var template = handlebars.compile(source);
@@ -50,7 +70,8 @@ function HttpHelper(connection, model, action, urlParams, values, context) {
 
             allParams = _.merge(_.cloneDeep(connection.urlParameters),
                                 _.cloneDeep(action.urlParameters) || {}, 
-                                _.cloneDeep(urlParams) || {});
+                                _.cloneDeep(urlParams) || {},
+                                mapQueryParams());
 
             _.keys(allParams).forEach(function(key) {
                 allParams[key] = self.interpolate(allParams[key]);
@@ -138,7 +159,7 @@ function HttpHelper(connection, model, action, urlParams, values, context) {
                     if (response.statusCode >= 200 && response.statusCode < 300) {
                         if (action.pathSelector === '') {
                             sails.log.debug('Object ' + action.objectNameMapping + 'has no response selector configured for ' +
-                                action.verb + ':' + action.path);
+                                action.verb + ':' + action.path + '. Ignoring response body.');
                             return cb(null, response, []);
                         }
 

--- a/test/unit/http-helper.test.js
+++ b/test/unit/http-helper.test.js
@@ -461,6 +461,52 @@ describe('Http-helper', function() {
 
             assert.equal(helper.constructUri(), 'http://localhost:1337/api/v1/model');
         });
+
+        it('should correctly map and include any scope query params', function(done) {
+            var context = {
+                query: {
+                    scope: 'all',
+                    query: {
+                        'longFieldName': 'abc555'
+                    }
+                }
+            };
+
+            var urlParams = {
+                'limit': 50,
+                'offset': 250
+            };
+
+            action.mapping.request = {
+                'longFieldName': 'long_field_name'
+            };
+
+            var helper = new Helper(connection, model, action, urlParams, {}, context);
+            var uri = helper.constructUri();
+            assert(uri.indexOf('long_field_name=abc555') !== -1);
+            done();
+        });
+
+        it('should include scope query params even if there is no mapping for that key', function(done) {
+            var context = {
+                query: {
+                    scope: 'all',
+                    query: {
+                        'longFieldName': 'abc555'
+                    }
+                }
+            };
+
+            var urlParams = {
+                'limit': 50,
+                'offset': 250
+            };
+
+            var helper = new Helper(connection, model, action, urlParams, {}, context);
+            var uri = helper.constructUri();
+            assert(uri.indexOf('longFieldName=abc555') !== -1);
+            done();
+        });
     });
 
     describe('constructHeaders function', function() {


### PR DESCRIPTION
...g request URI when both the query.query scope keys are present in the context. Keys are mapped according to the configured request mapping, if no mapping is present for a key, it is appended as-is.
