### PR TITLE
[Fixes #89242834] If no body payload template is supplied, ID is inserte...

### DIFF
--- a/lib/mappers.js
+++ b/lib/mappers.js
@@ -48,7 +48,7 @@ function JsonMapper(model, action, context) {
             } else if (idType === 'text') {
                 newModel['id'] = context.params.id;
             } else if (idType === 'date' || idType === 'datetime') {
-                newModel['id'] = new Date(context.params.id)
+                newModel['id'] = new Date(context.params.id).toJSON();
             } else if (idType === 'boolean') {
                 newModel['id'] = context.params.id === 'true';
             } else {

--- a/lib/mappers.js
+++ b/lib/mappers.js
@@ -40,7 +40,21 @@ function JsonMapper(model, action, context) {
         // Supply ID to the model if none is present and we can find one in
         // the params. Only applies to PUT and POST verbs.
         if (!newModel['id'] && context.params && context.params.id && _.contains(['PUT', 'POST'], action.verb)) {
-            newModel['id'] = context.params.id;
+            var idType = attributes['id']['type'];
+            // not sure why you'd need to support anything other than text and integer (anything else for a key would seem like an odd use case),
+            // but let's support it anyway for sake of being thorough ....
+            if (idType === 'integer' || idType === 'float') {
+                newModel['id'] = Number(context.params.id);
+            } else if (idType === 'text') {
+                newModel['id'] = context.params.id;
+            } else if (idType === 'date' || idType === 'datetime') {
+                newModel['id'] = new Date(context.params.id)
+            } else if (idType === 'boolean') {
+                newModel['id'] = context.params.id === 'true';
+            } else {
+                cb(new Error("id field of type " + idType + " is not supported!"));
+            }
+            
         }
 
         return cb(null, newModel);


### PR DESCRIPTION
...d into body payload -- make sure datatype gets converted correctly to what the remote data source is expecting
