### PR TITLE
Unmapped fields being returned from responses.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false

--- a/lib/mappers.js
+++ b/lib/mappers.js
@@ -19,10 +19,6 @@ function JsonMapper(model, action, context) {
             if (_.has(map, key)) {
                 var val = jsonPath.eval(obj, map[key])[0];
                 newModel[key] = val;
-            } else {
-                // If no mapping for a key is found, attempt to get the value from
-                // the payload object under the same key.
-                newModel[key] = obj[key];
             }
         });
 
@@ -54,7 +50,7 @@ function JsonMapper(model, action, context) {
             } else {
                 cb(new Error("id field of type " + idType + " is not supported!"));
             }
-            
+
         }
 
         return cb(null, newModel);
@@ -82,7 +78,7 @@ function JsonMapper(model, action, context) {
             } else {
                 nodes = jsonPath.eval(payload, action.pathSelector);
             }
-            
+
             if (!nodes) return cb(new Error('Could not find any valid models in returned payload. Please check your selector. Payload: ' + util.inspect(payload)));
 
             mapAllNodes(nodes, _mapResponse, function(err, result) {
@@ -119,7 +115,9 @@ function XmlMapper(model, action, context) {
         _.keys(attributes).forEach(function(key) {
             if (_.isFunction(attributes[key])) return;
 
-            var map = mapping.response[key] || key + '/text()';
+            var map = mapping.response[key];
+
+            if (!map) return;
 
             var isXpath = (map.indexOf('/') !== -1 ||
                            map.indexOf('//') !== -1 ||
@@ -155,7 +153,7 @@ function XmlMapper(model, action, context) {
 
                 if (tag) payload += '<' + tag + '>' + obj[key] + '</' + tag + '>';
             });
-            payload += '</' + root + '>';            
+            payload += '</' + root + '>';
         });
 
         if (isCollection) payload += '</collection>';


### PR DESCRIPTION
[#92490278] Fixed an issue where unmapped response fields were being returned. There was an incorrect assumption that if no mapping existed for a field, the mapper should attempt to find it on the object by looking for a matching key.

Also added an editorconfig file to maintain indentation in project.
