### PR TITLE
Removed sails requirement for logging. If sails is not found, such as…

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var Helper = require('./http-helper'),
-    util = require('util'),
-    _ = require('lodash');
+var Helper  = require('./http-helper'),
+    util    = require('util'),
+    _       = require('lodash'),
+    log     = require('./log');
 
 
 function remoteError(err, connection, response, result) {
@@ -68,7 +69,7 @@ module.exports = (function () {
             helper.makeRequest(function(err, response, result) {
                 if (err) return cb(remoteError(err, connection, response, result));
 
-                sails.log.debug('response received: ' + util.inspect({
+               log('response received: ' + util.inspect({
                   status: response.statusCode,
                   configuration: action,
                   body: response.body

--- a/lib/http-helper.js
+++ b/lib/http-helper.js
@@ -7,7 +7,8 @@ var mappers = require('./mappers'),
     util = require('util'),
     request = require('request'),
     _ = require('lodash'),
-    handlebars = require('handlebars');
+    handlebars = require('handlebars'),
+    log = require('./log');
 
 var mimes = {
     'json': 'application/json',
@@ -54,7 +55,7 @@ HttpHelper.prototype.mapRequest = function(cb) {
 
 HttpHelper.prototype.constructBody = function(cb) {
     var self = this;
-    
+
     // If action has a body template, construct and return it.
     if (self.action.bodyPayloadTemplate && !_.isEmpty(self.action.bodyPayloadTemplate)) {
         return cb(null, self.interpolate(self.action.bodyPayloadTemplate));
@@ -63,7 +64,7 @@ HttpHelper.prototype.constructBody = function(cb) {
     // If we have no body template result and the values supplied are empty,
     // return nothing.
     if (_.isEmpty(self.values)) return cb();
-    
+
     self.mapRequest(function(err, res) {
         if (err) return cb(err);
 
@@ -75,7 +76,7 @@ HttpHelper.prototype.constructBody = function(cb) {
 HttpHelper.prototype.mapQueryParams = function() {
     var self = this;
 
-    var q = {}, 
+    var q = {},
         map = self.action.mapping.request,
         keys = _.keys(self.queryParams);
 
@@ -91,7 +92,7 @@ HttpHelper.prototype.mapQueryParams = function() {
 
 HttpHelper.prototype.constructHeaders = function() {
     var self = this;
-    
+
     var headers = {};
 
     /* Content negotiation headers
@@ -137,7 +138,7 @@ HttpHelper.prototype.constructUri = function() {
     var allParams;
 
     allParams = _.merge(_.cloneDeep(self.connection.urlParameters),
-                        _.cloneDeep(self.action.urlParameters) || {}, 
+                        _.cloneDeep(self.action.urlParameters) || {},
                         _.cloneDeep(self.urlParams) || {},
                         self.mapQueryParams());
 
@@ -161,7 +162,7 @@ HttpHelper.prototype.interpolate = function(source) {
 
 HttpHelper.prototype.makeRequest = function(cb) {
     var self = this;
-    
+
     self.constructBody(function(err, res) {
         if (err) return cb(err);
 
@@ -172,11 +173,11 @@ HttpHelper.prototype.makeRequest = function(cb) {
             body: res || ''
         };
 
-        sails.log.debug('request made with options: ' + util.inspect(
+        log('request made with options: ' + util.inspect(
             {
                 params:params,
                 configuration: self.action
-            }, 
+            },
             { depth: null }));
 
         request(params, function(err, response, result) {
@@ -184,7 +185,7 @@ HttpHelper.prototype.makeRequest = function(cb) {
 
             var parsedResponse = null;
             var parseError = null;
-            
+
             // get the parsed response
             try {
                 parsedResponse = payloadParsers[self.action.format]().parse(result);
@@ -198,7 +199,7 @@ HttpHelper.prototype.makeRequest = function(cb) {
 
             if (response.statusCode >= 200 && response.statusCode < 300) {
                 if (self.action.pathSelector === '') {
-                    sails.log.debug('Object ' + self.action.objectNameMapping + 'has no response selector configured for ' +
+                    log('Object ' + self.action.objectNameMapping + 'has no response selector configured for ' +
                         self.action.verb + ':' + self.action.path + '. Ignoring response body.');
                     return cb(null, response, []);
                 }

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,4 @@
+module.exports = function(message) {
+    if (typeof sails !== 'undefined') return sails.log.debug(message);
+    console.log("debug: " + message);
+};

--- a/test/bootstrap-waterline.js
+++ b/test/bootstrap-waterline.js
@@ -3,16 +3,6 @@ var Waterline = require('waterline'),
     _ = require('lodash'),
     util = require('util');
 
-//Stub the global sails object, for logging
-sails = {
-    log: {
-        debug: function(msg) {
-            // console.log('debug: ' + msg);
-            return;
-        }
-    }
-};
-
 module.exports = function(connections, collections, cb) {
     var waterline = new Waterline();
 


### PR DESCRIPTION
… in testing or using stand-alone waterline, it will fallback to logging to the console.
